### PR TITLE
new THREE.CanvasRenderer(); is Error of Chrome 38

### DIFF
--- a/app/templates/main.js
+++ b/app/templates/main.js
@@ -29,7 +29,11 @@ function init() {
     mesh = new THREE.Mesh(geometry, material);
     scene.add(mesh);
 
-    renderer = new THREE.CanvasRenderer();
+    if (window.WebGLRenderingContext) {
+        renderer = new THREE.WebGLRenderer();
+    } else {
+        renderer = new THREE.CanvasRenderer();
+    };
     renderer.setSize(window.innerWidth, window.innerHeight);
 
     document.body.appendChild(renderer.domElement);


### PR DESCRIPTION
It is now in error when rendering If you are using the chrome.

```
Uncaught TypeError: undefined is not a function
```