### PR TITLE
Fix "Warning: Path must be a string."

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,7 +26,8 @@ module.exports = function(grunt) {
 		},
 		jshint: {
 			options: {
-				jshintrc: '.jshintrc'
+				jshintrc: '.jshintrc',
+				reporterOutput: ""
 			},
 			grunt: [ 'Gruntfile.js' ],
 			main: [ 'app/*.js', 'test/*.js' ]


### PR DESCRIPTION
I received an error when running `grunt`:

    Running "jshint:all" (jshint) task
    Warning: Path must be a string. Received null Use --force to continue.
    Aborted due to warnings.

This commit adds a blank string to the jshint reporter output, bingo, no error.
https://github.com/jshint/jshint/issues/2922